### PR TITLE
Issue #11 Wrong paths when generating actions and reducers in Windows

### DIFF
--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -31,12 +31,14 @@ const write = function(path, tree) {
 
 const getDestinationPath = function(name, type, suffix) {
   const prefix = path.join('src', type, name);
-  return [prefix, suffix].join('.');
+  const portablePrefix = path.sep === '/' ? prefix : prefix.split(path.sep).join('/');
+  return [portablePrefix, suffix].join('.');
 };
 
 const getRelativePath = function(name, type, suffix) {
   const filePath = path.join('..', type, name);
-  return [filePath, suffix].join('.');
+  const portableFilePath = path.sep === '/' ? filePath : filePath.split(path.sep).join('/');
+  return [portableFilePath, suffix].join('.');
 };
 
 const getBaseName = function(path) {


### PR DESCRIPTION
I dind't change the method to join the path directly to `[...].join('/')` because if the final user generates an element using windows paths, it wouldn't work. 
This way it doesn't matter how the user enters the path of the element hi or she wants to create, the final result will always be in unix format. 

I hope this helps!