### PR TITLE
Hardcoded version of escodegen-wallaby.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "release:patch": "npm version patch && npm publish && git push --follow-tags"
   },
   "dependencies": {
-    "escodegen-wallaby": "^1.6.5",
+    "escodegen-wallaby": "1.6.6",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "esprima-walk": "^0.1.0",
     "generator-react-webpack": "3.2.2",


### PR DESCRIPTION
I found the problem. I upgraded the generator. That also installed the newest version of escodegen-wallaby (1.6.7). Support for ExportDeclaration has been dropped and replaced by more specific types. Unfortunately, esprima-fb still outputs ExportDeclaration, so updating the const and App files no longer works.

I fixed it by downgrading to escodegen-wallaby@1.6.6