### PR TITLE
Optionally include redux-thunk, resolve #73

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,6 +8,18 @@ class AppGenerator extends Generator {
     this.option('skip-install');
   }
 
+  prompting() {
+    return this.prompt([{
+      type: 'confirm',
+      name: 'thunk',
+      message: 'Would you like to include redux-thunk?',
+      default: false,
+      store: true,
+    }]).then(answers => {
+      this.thunk = answers.thunk;
+    });
+  }
+
   install() {
     if(!this.options['skip-install']) {
       this.installDependencies({ bower: false });
@@ -29,11 +41,18 @@ class AppGenerator extends Generator {
 
       // Run the create root method
       this.composeWith('react-webpack-redux:root', {
-        args: ['Root']
+        args: ['Root'],
+        thunk: this.thunk,
       });
 
-      // Install redux and react bindings as requirement
-      this.npmInstall(['redux', 'react-redux'], { 'save': true });
+      // Install redux and react bindings as requirement and redux-thunk optionally
+      let packages = ['redux', 'react-redux'];
+
+      if (this.thunk) {
+        packages.push('redux-thunk');
+      }
+
+      this.npmInstall(packages, { 'save': true });
     });
   }
 };

--- a/generators/root/index.js
+++ b/generators/root/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const Generator = require('yeoman-generator');
-const fs = require('fs');
 
 class RootGenerator extends Generator {
   writing() {
@@ -12,7 +11,7 @@ class RootGenerator extends Generator {
 
     // Copy the store
     this.fs.copy(
-      this.templatePath('store.js'),
+      this.options.thunk ? this.templatePath('store-thunk.js') : this.templatePath('store.js'),
       this.destinationPath('src/stores/index.js')
     );
 
@@ -52,6 +51,7 @@ class RootGenerator extends Generator {
       this.destinationPath('.eslintrc')
     );
   }
+
 };
 
 module.exports = RootGenerator;

--- a/generators/root/templates/store-thunk.js
+++ b/generators/root/templates/store-thunk.js
@@ -1,0 +1,25 @@
+
+import { createStore, compose, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import reducers from '../reducers';
+
+function reduxStore(initialState) {
+  const store = createStore(reducers, initialState, compose(
+    applyMiddleware(thunk),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ));
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', function () {
+      // We need to require for hot reloading to work properly.
+      const nextReducer = require('../reducers');  // eslint-disable-line global-require
+
+      store.replaceReducer(nextReducer);
+    });
+  }
+
+  return store;
+}
+
+export default reduxStore;


### PR DESCRIPTION
I've tried to implement it with esprima + escodegen and a gulp transform to keep the original store file but change it in memory to include redux-thunk but I had an issue with the output of esprima not being supported by escodegen, so I ended up creating a new file: `store-thunk.js` . Pros: it works, Cons: if you change the store file you have to change both the thunk and not thunk versions. Shouldn't be too much of a problem.

All tests passed. Great generator by the way, I use it for all my front-end proyects and I'm glad to contribute. I'll subscribe to the issues to help with the support and see nobody has a problem with this enhancement.