### PR TITLE
Allow missing app container

### DIFF
--- a/generators/action/index.js
+++ b/generators/action/index.js
@@ -155,7 +155,9 @@ class ActionGenerator extends Generator {
     this.exportAction(indexPath, relativePath, baseName);
 
     // Add action to App.js
-    this.attachToApp(appPath, baseName);
+    if(utils.isPresent(appPath)) {
+      this.attachToApp(appPath, baseName);
+    }
   }
 };
 

--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -5,6 +5,10 @@ const path = require('path');
 const esprimaFb = require('esprima-fb');
 const escodegenJsx = require('escodegen-wallaby');
 
+const isPresent = function(path) {
+  return fs.existsSync(path);
+};
+
 const read = function(path) {
   const data = fs.readFileSync(path, 'utf8');
   const options = {
@@ -49,6 +53,7 @@ const getBaseName = function(path) {
 };
 
 module.exports = {
+  isPresent: isPresent,
   read: read,
   write: write,
   getDestinationPath: getDestinationPath,

--- a/generators/reducer/index.js
+++ b/generators/reducer/index.js
@@ -144,7 +144,7 @@ class ReducerGenerator extends Generator {
     this.attachToRoot(rootReducerPath, relativePath, baseName);
 
     // Add the reducer to App.js
-    if(utils.isPresent(appPath)){
+    if(utils.isPresent(appPath)) {
       this.attachToApp(appPath, baseName);
     }
   }

--- a/generators/reducer/index.js
+++ b/generators/reducer/index.js
@@ -144,7 +144,9 @@ class ReducerGenerator extends Generator {
     this.attachToRoot(rootReducerPath, relativePath, baseName);
 
     // Add the reducer to App.js
-    this.attachToApp(appPath, baseName);
+    if(utils.isPresent(appPath)){
+      this.attachToApp(appPath, baseName);
+    }
   }
 };
 

--- a/test/generators/reducer/indexTest.js
+++ b/test/generators/reducer/indexTest.js
@@ -94,7 +94,7 @@ describe('react-webpack-redux:reducer', () => {
           done();
         });
       });
-    })
+    });
 
     context('without App.js', () => {
       it('should not add the reducer to App.js', (done) => {
@@ -103,7 +103,7 @@ describe('react-webpack-redux:reducer', () => {
           done();
         });
       });
-    })
+    });
 
   });
 });

--- a/test/generators/reducer/indexTest.js
+++ b/test/generators/reducer/indexTest.js
@@ -19,17 +19,34 @@ describe('react-webpack-redux:reducer', () => {
      * @param {String} name
      * @param {Function} callback
      */
-    function createGeneratedReducer(name, callback) {
-      helpers.run(generatorReducer)
-        .inTmpDir((tmpDir) => {
-          rootReducerPath = path.join(tmpDir, 'src/reducers/index.js');
-          fs.copySync(reducerSource, rootReducerPath);
+    function createGeneratedReducer(...args) {
+      runGeneratorWithTmpDir(...args, (tmpDir) => {
+        copyRootReducer(tmpDir);
+        copyAppContainer(tmpDir);
+      })
+    }
 
-          appPath = path.join(tmpDir, 'src/containers/App.js');
-          fs.copySync(appSource, appPath);
-        })
+    function createGeneratedReducerWithoutAppContainer(...args) {
+      runGeneratorWithTmpDir(...args, (tmpDir) => {
+        copyRootReducer(tmpDir);
+      })
+    }
+
+    function runGeneratorWithTmpDir(name, callback, tmpDirFn){
+      helpers.run(generatorReducer)
+        .inTmpDir(tmpDirFn)
         .withArguments([name])
         .on('end', callback);
+    }
+
+    function copyRootReducer(tmpDir){
+      rootReducerPath = path.join(tmpDir, 'src/reducers/index.js');
+      fs.copySync(reducerSource, rootReducerPath);
+    }
+
+    function copyAppContainer(tmpDir){
+      appPath = path.join(tmpDir, 'src/containers/App.js');
+      fs.copySync(appSource, appPath);
     }
 
     it('should create a reducer when invoked', (done) => {
@@ -65,16 +82,28 @@ describe('react-webpack-redux:reducer', () => {
       });
     });
 
-    it('should add the reducer to App.js', (done) => {
+    context('with App.js', () => {
+      it('should add the reducer to App.js', (done) => {
 
-      createGeneratedReducer('test', () => {
-        assert.fileContent(appPath, '/* Populated by react-webpack-redux:reducer */');
-        assert.fileContent(appPath, 'test: state.test');
-        assert.fileContent(appPath, 'const {actions, test} = this.props;');
-        assert.fileContent(appPath, '<Main actions={actions} test={test}/>');
-        assert.fileContent(appPath, 'test: PropTypes.shape({})');
-        done();
+        createGeneratedReducer('test', () => {
+          assert.fileContent(appPath, '/* Populated by react-webpack-redux:reducer */');
+          assert.fileContent(appPath, 'test: state.test');
+          assert.fileContent(appPath, 'const {actions, test} = this.props;');
+          assert.fileContent(appPath, '<Main actions={actions} test={test}/>');
+          assert.fileContent(appPath, 'test: PropTypes.shape({})');
+          done();
+        });
       });
-    });
+    })
+
+    context('without App.js', () => {
+      it('should not add the reducer to App.js', (done) => {
+
+        createGeneratedReducerWithoutAppContainer('test', () => {
+          done();
+        });
+      });
+    })
+
   });
 });


### PR DESCRIPTION
This allows developers to run the sub-generators after they have removed the app container - it isn't always useful to have all the props and actions exposed to the root component in this way.